### PR TITLE
nzhw == None -> nzhw is None

### DIFF
--- a/split_combine.py
+++ b/split_combine.py
@@ -60,7 +60,7 @@ class SplitComb():
             stride = self.stride
         if margin == None:
             margin = self.margin
-        if nzhw==None:
+        if nzhw is None:
             nz = self.nz
             nh = self.nh
             nw = self.nw


### PR DESCRIPTION
nzhw is a `np.array` , `nzhw == None` returns a bool type `np.array` which is not suitable to be the condition of `if`(will raise error), so change it into `nzhw is None`